### PR TITLE
Render GitHub activity cards

### DIFF
--- a/public/cm2git/cm2git.css
+++ b/public/cm2git/cm2git.css
@@ -7,3 +7,38 @@ body {
 #app {
   padding: 1rem;
 }
+
+#activity {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.activity-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  text-decoration: none;
+  color: inherit;
+  background: #fff;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.activity-item:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.activity-type {
+  font-weight: bold;
+  text-transform: uppercase;
+}
+
+.activity-date {
+  font-size: 0.875rem;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- render fetched pull requests, commits, and merges as cards with author, date, and GitHub link
- add responsive grid and hover styles for activity cards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b33a70187883289fdc474e5f1413ba